### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ This class works fine with iOS >= 5.0 and OS X >= 10.7 applications (ARC require
 
 ### Manual
 
-Download and add `RMRUTValidator.h` and `RMRUTValidator.m` files to your XCode project.
+Download and add `RMRUTValidator.h` and `RMRUTValidator.m` files to your Xcode project.
 
 ### Cocoapods
 
-Create the `Porfile` file in your XCode project root directory with the following:
+Create the `Porfile` file in your Xcode project root directory with the following:
 
 ```ruby
 platform :ios, '5.0'


### PR DESCRIPTION

This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
