### PR TITLE
Added exception with digit 0 (zero)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ RMRUTValidator
 Simple class to validate chilean security number, also known as RUT.
 
 ## Requirements
-This class works fine with iOS >= 5.0 and OS X >= 10.7 applications (ARC required, of course).
+This class works fine with iOS >= 9.0 and OS X >= 10.7 applications (ARC required, of course).
 
 ## Installation
 
@@ -19,7 +19,7 @@ Download and add `RMRUTValidator.h` and `RMRUTValidator.m` files to your XCode p
 Create the `Porfile` file in your XCode project root directory with the following:
 
 ```ruby
-platform :ios, '5.0'
+platform :ios, '9.0'
 
 pod 'RMRUTValidator'
 ```
@@ -35,7 +35,7 @@ pod install
 Import the `RMRUTValidator.h` file where you need to use it.
 
 ```objc
-#import "RMRUTValidator.h"
+#import <RMRUTValidator/RMRUTValidator.h>
 ```
 
 Then you validate a RUT like this:

--- a/RMRUTValidator.podspec
+++ b/RMRUTValidator.podspec
@@ -1,15 +1,15 @@
 Pod::Spec.new do |s|
   s.name         = 'RMRUTValidator'
-  s.version      = '0.0.1'
+  s.version      = '0.0.2'
   s.summary      = 'Simple class to validate chilean security number, also known as RUT.'
   s.homepage     = 'https://github.com/renatomoya/RMRUTValidator'
   s.license      = 'MIT'
   s.author       = { 'Renato Moya' => 'imexto@gmail.com' }
 
-  s.ios.deployment_target = '5.0'
+  s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.7'
 
-  s.source       = { :git => 'https://github.com/renatomoya/RMRUTValidator.git', :tag => '0.0.1' }
+  s.source       = { :git => 'https://github.com/renatomoya/RMRUTValidator.git', :tag => s.version.to_s }
   s.source_files  = 'RMRUTValidator/Classes/0.0.1/RMRUTValidator.{h,m}'
 
   s.requires_arc = true

--- a/RMRUTValidator/Classes/0.0.1/RMRUTValidator.m
+++ b/RMRUTValidator/Classes/0.0.1/RMRUTValidator.m
@@ -37,6 +37,9 @@
     
     NSInteger digitCalculation = 11 - (numbersSum % 11);
 
+    if (digitCalculation == 11)
+        digitCalculation = 0;
+    
     NSString *computedDigit = digitCalculation == 10 ? @"K" : [NSString stringWithFormat:@"%d", (int)digitCalculation];
     
     if ([digit.uppercaseString isEqualToString:computedDigit]) {

--- a/RMRUTValidator/RMRUTValidator.xcodeproj/project.pbxproj
+++ b/RMRUTValidator/RMRUTValidator.xcodeproj/project.pbxproj
@@ -201,7 +201,11 @@
 				LastUpgradeCheck = 0500;
 				ORGANIZATIONNAME = "Renato Moya";
 				TargetAttributes = {
+					E3F016E317E47FA500EC36B4 = {
+						DevelopmentTeam = N682HHE6U7;
+					};
 					E3F016FE17E47FA500EC36B4 = {
+						DevelopmentTeam = N682HHE6U7;
 						TestTargetID = E3F016E317E47FA500EC36B4;
 					};
 				};
@@ -325,7 +329,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 			};
@@ -358,7 +362,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -369,6 +373,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = N682HHE6U7;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "RMRUTValidator/RMRUTValidator-Prefix.pch";
 				INFOPLIST_FILE = "RMRUTValidator/RMRUTValidator-Info.plist";
@@ -382,6 +388,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				DEVELOPMENT_TEAM = N682HHE6U7;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "RMRUTValidator/RMRUTValidator-Prefix.pch";
 				INFOPLIST_FILE = "RMRUTValidator/RMRUTValidator-Info.plist";
@@ -395,6 +403,8 @@
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/RMRUTValidator.app/RMRUTValidator";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = N682HHE6U7;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -418,6 +428,8 @@
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/RMRUTValidator.app/RMRUTValidator";
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				DEVELOPMENT_TEAM = N682HHE6U7;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",

--- a/RMRUTValidator/RMRUTValidator/AppDelegate.m
+++ b/RMRUTValidator/RMRUTValidator/AppDelegate.m
@@ -16,6 +16,9 @@
     // Override point for customization after application launch.
     self.window.backgroundColor = [UIColor whiteColor];
     [self.window makeKeyAndVisible];
+    
+    UIViewController* rootViewController = [[UIViewController alloc] init];
+    self.window.rootViewController = rootViewController;
     return YES;
 }
 

--- a/RMRUTValidator/RMRUTValidatorTests/RMRUTValidatorTests.m
+++ b/RMRUTValidator/RMRUTValidatorTests/RMRUTValidatorTests.m
@@ -62,4 +62,58 @@
     XCTAssertFalse([RMRUTValidator validateRut:@"INVALID"], @"The rut is invalid");
 }
 
+/*
+ * specific cases
+ */
+
+- (void)testValidateRutWithDigit0
+{
+    XCTAssertTrue([RMRUTValidator validateRut:@"14.400.400-0"], @"The rut is invalid");
+}
+
+- (void)testValidateRutWithDigit1
+{
+    XCTAssertTrue([RMRUTValidator validateRut:@"14.400.405-1"], @"The rut is invalid");
+}
+
+- (void)testValidateRutWithDigit2
+{
+    XCTAssertTrue([RMRUTValidator validateRut:@"14.400.413-2"], @"The rut is invalid");
+}
+
+- (void)testValidateRutWithDigit3
+{
+    XCTAssertTrue([RMRUTValidator validateRut:@"14.400.404-3"], @"The rut is invalid");
+}
+
+- (void)testValidateRutWithDigit4
+{
+    XCTAssertTrue([RMRUTValidator validateRut:@"14.400.409-4"], @"The rut is invalid");
+}
+
+- (void)testValidateRutWithDigit5
+{
+    XCTAssertTrue([RMRUTValidator validateRut:@"14.400.403-5"], @"The rut is invalid");
+}
+
+- (void)testValidateRutWithDigit6
+{
+    XCTAssertTrue([RMRUTValidator validateRut:@"14.400.408-6"], @"The rut is invalid");
+}
+
+- (void)testValidateRutWithDigit7
+{
+    XCTAssertTrue([RMRUTValidator validateRut:@"14.400.402-7"], @"The rut is invalid");
+}
+
+- (void)testValidateRutWithDigit8
+{
+    XCTAssertTrue([RMRUTValidator validateRut:@"14.400.407-8"], @"The rut is invalid");
+}
+
+- (void)testValidateRutWithDigit9
+{
+    XCTAssertTrue([RMRUTValidator validateRut:@"14.400.401-9"], @"The rut is invalid");
+}
+
 @end


### PR DESCRIPTION
The validator returns false for the RUTs with digit 0 like _14.400.400-0_, _10.551.825-0_ and _15856945-0_

The project version was also updated (to iOS 9), specific unit tests were added for each digit and the Podspec file was updated. It would only be enough to place the tag 0.0.2 for the Cocoapods 🤘